### PR TITLE
Fix bug where calorie data reset to 0 after editing

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -19,6 +19,7 @@ import seedu.address.model.Model;
 import seedu.address.model.day.Date;
 import seedu.address.model.day.Day;
 import seedu.address.model.day.Weight;
+import seedu.address.model.day.calorie.CalorieManager;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -85,8 +86,9 @@ public class EditCommand extends Command {
         Date updatedDate = editDayDescriptor.getDate().orElse(dayToEdit.getDate());
         Weight updatedWeight = editDayDescriptor.getWeight().orElse(dayToEdit.getWeight());
         Set<Tag> updatedTags = editDayDescriptor.getTags().orElse(dayToEdit.getTags());
+        CalorieManager calorieManager = dayToEdit.getCalorieManager();
 
-        return new Day(updatedDate, updatedWeight, updatedTags);
+        return new Day(updatedDate, updatedWeight, updatedTags, calorieManager);
     }
 
     @Override


### PR DESCRIPTION
Fixed bug where calorie data reset to 0 after editing.
A copy of the Calorie Manager is parsed to the Day constructor since every edit command creates a new Day object.
Since edit command does not edit any calorie values, this fix does not affect the integrity of Calorie Manager.