### PR TITLE
Disable CodeCov for JavaCI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Build and check with Gradle
         run: ./gradlew check coverage
 
-      - uses: codecov/codecov-action@v1
-        if: runner.os == 'Linux'
-        with:
-          file: ${{ github.workspace }}/build/reports/jacoco/coverage/coverage.xml
-          fail_ci_if_error: true
+#      - uses: codecov/codecov-action@v1
+#        if: runner.os == 'Linux'
+#        with:
+#          file: ${{ github.workspace }}/build/reports/jacoco/coverage/coverage.xml
+#          fail_ci_if_error: true


### PR DESCRIPTION
* Disabled CodeCov checks for CI due to an issue on GitHub Actions/CodeCov